### PR TITLE
DotnetSDK: use hardcoded Pulumi version

### DIFF
--- a/sdk/dotnet/Pulumi.Vultr.csproj
+++ b/sdk/dotnet/Pulumi.Vultr.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi" Version="3.54.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since this package is always built by our CI before use,
using wildcard causes our program to always require
the latest Pulumi version which is not ideal.

This commit hardcodes the Pulumi version to 3.54.0.
